### PR TITLE
update stackr ref to epiforecasts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Imports:
     HDInterval,
     R.utils
 Remotes:
-    nikosbosse/stackr
+    epiforecasts/stackr
 Suggests: 
     knitr,
     rmarkdown,


### PR DESCRIPTION
because `epiforecasts/stackr` seems to have continued the development on `nikosbosse/stackr`